### PR TITLE
Remove duplicate JUnit dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <version>4.3.0</version>


### PR DESCRIPTION
JUnit version 4.11 is declared twice within pom.xml. This PR removes this redundant duplication.